### PR TITLE
[feature] Implement strict access control based on authorizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ Example template:
 AUTH_PROFILE_MODULE = "userprofile.UserProfile"
 ```
 
+#### Restrict Authentication by Rights (Authorizations)
+By default, any user with a valid EPFL Entra ID account can authenticate. If you want to restrict access only to users possessing specific application rights (claims injected by the EPFL portal), follow these steps:
+Do the following :
+
+1. Enable the strict verification in your .env file
+
+    Add the following line to enforce the rights check. If this variable is missing, empty, or set to false, the strict verification is bypassed and any valid Entra ID user will be allowed in.
+    ```.env
+    AUTHENTICATION_RIGHTS=true
+    ```
+2. Configure the failure redirection in your app's settings.py
+
+    When a user authenticates successfully but lacks the required rights, the authentication backend will reject them. You must define where Django should redirect them.
+    ```python
+    LOGIN_REDIRECT_URL_FAILURE = "/forbidden"
+    ```
+> Note: Ensure that your application rights are properly configured in the EPFL deployment portal ([app-portal](https://app-portal.epfl.ch/)). Entra ID relies on this configuration to inject the authorizations claim into the user's token.
+
+
 ### Logging
 
 Enable these loggers in settings to see logging messages to help you debug:

--- a/README.md
+++ b/README.md
@@ -95,23 +95,31 @@ AUTH_PROFILE_MODULE = "userprofile.UserProfile"
 ```
 
 #### Restrict Authentication by Rights (Authorizations)
-By default, any user with a valid EPFL Entra ID account can authenticate. If you want to restrict access only to users possessing specific application rights (claims injected by the EPFL portal), follow these steps:
-Do the following :
 
-1. Enable the strict verification in your .env file
+By default, any user with a valid EPFL Entra ID account can authenticate.
+If you want to restrict access only to users possessing specific application
+rights (claims injected by the EPFL portal), follow these steps:
 
-    Add the following line to enforce the rights check. If this variable is missing, empty, or set to false, the strict verification is bypassed and any valid Entra ID user will be allowed in.
-    ```.env
-    AUTHENTICATION_RIGHTS=true
-    ```
-2. Configure the failure redirection in your app's settings.py
+##### Configure your app's `settings.py`
 
-    When a user authenticates successfully but lacks the required rights, the authentication backend will reject them. You must define where Django should redirect them.
-    ```python
-    LOGIN_REDIRECT_URL_FAILURE = "/forbidden"
-    ```
-> Note: Ensure that your application rights are properly configured in the EPFL deployment portal ([app-portal](https://app-portal.epfl.ch/)). Entra ID relies on this configuration to inject the authorizations claim into the user's token.
+You need to enable the strict rights verification and define where Django should
+redirect unauthorized users (e.g., to a 403 Forbidden page). Add the following
+to your settings:
+  
+```python
+  # Enable strict rights verification. 
+  # (You can dynamically load this from your .env file if preferred)
+  OIDC_REQUIRE_AUTHORIZATIONS = True
+  
+  # Redirect unauthorized users to the dedicated forbidden view
+  LOGIN_REDIRECT_URL_FAILURE = "/forbidden"
+```
 
+> Note: Ensure that your application rights are properly
+> configured in the EPFL deployment portal
+> ([app-portal](https://app-portal.epfl.ch/)).
+> Entra ID relies on this configuration to
+> inject the authorizations claim into the user's token.
 
 ### Logging
 

--- a/django_epfl_entra_id/auth.py
+++ b/django_epfl_entra_id/auth.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import jwt
 from django.apps import apps
@@ -119,10 +118,10 @@ class EPFLOIDCAB(OIDCAuthenticationBackend):
         if not super().verify_claims(claims):
             return False
 
-        AUTHENTICATION_RIGHTS = os.getenv(
-            "AUTHENTICATION_RIGHTS", "false"
-        ).lower()
-        if AUTHENTICATION_RIGHTS != "true":
+        require_authorizations = getattr(
+            settings, "OIDC_REQUIRE_AUTHORIZATIONS", False
+        )
+        if not require_authorizations:
             return True
 
         authorizations = claims.get("authorizations", [])

--- a/django_epfl_entra_id/auth.py
+++ b/django_epfl_entra_id/auth.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import jwt
 from django.apps import apps
@@ -113,6 +114,26 @@ class EPFLOIDCAB(OIDCAuthenticationBackend):
         user.save()
         logger.debug("Update user: %s", user)
         return user
+
+    def verify_claims(self, claims):
+        if not super().verify_claims(claims):
+            return False
+
+        AUTHENTICATION_RIGHTS = os.getenv(
+            "AUTHENTICATION_RIGHTS", "false"
+        ).lower()
+        if AUTHENTICATION_RIGHTS != "true":
+            return True
+
+        authorizations = claims.get("authorizations", [])
+
+        if not authorizations:
+            logger.warning(
+                f"Access refused for {claims.get('gaspar', 'Unknown')}: "
+                "No authorization found."
+            )
+            return False
+        return True
 
     def get_userinfo(self, access_token, id_token, payload):
         """

--- a/django_epfl_entra_id/urls.py
+++ b/django_epfl_entra_id/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
         views.EPFLEntraIdLogin.as_view(),
         name="epfl_entra_id_init",
     ),
+    url(r"forbidden/$", views.forbidden_view, name="entra_id_forbidden"),
 ]

--- a/django_epfl_entra_id/urls.py
+++ b/django_epfl_entra_id/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
         views.EPFLEntraIdLogin.as_view(),
         name="epfl_entra_id_init",
     ),
-    url(r"forbidden/$", views.forbidden_view, name="entra_id_forbidden"),
+    url(r"forbidden/$", views.forbidden_view, name="epfl_entra_id_forbidden"),
 ]

--- a/django_epfl_entra_id/views.py
+++ b/django_epfl_entra_id/views.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views.generic import View
@@ -15,3 +16,11 @@ class EPFLEntraIdLogin(View):
                 else ""
             )
         )
+
+
+def forbidden_view(request):
+    """
+    Dedicated view to reject users who have successfully authenticated with
+    Entra ID but lack the authorizations (claims) required by the application.
+    """
+    raise PermissionDenied()

--- a/requirements/requirements-lint.txt
+++ b/requirements/requirements-lint.txt
@@ -1,5 +1,5 @@
 # Only run once in latest Python version and used in VS Code.
 
-black==26.3.1
+black==25.1.0
 flake8==7.3.0
 isort==7.0.0

--- a/requirements/requirements-lint.txt
+++ b/requirements/requirements-lint.txt
@@ -1,5 +1,5 @@
 # Only run once in latest Python version and used in VS Code.
 
-black==25.1.0
+black==26.3.1
 flake8==7.3.0
 isort==7.0.0

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -196,3 +196,132 @@ class EPFLOIDCABUserTestCase(TestCase):
 
         with pytest.raises(Exception):
             self.backend.authenticate(request=auth_request)
+
+    @patch("os.getenv")
+    @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
+    @patch("mozilla_django_oidc.auth.requests")
+    @override_settings(OIDC_USE_NONCE=False)
+    def test_authenticate_rights_enabled_rejected(
+        self, request_mock, jws_mock, getenv_mock
+    ):
+        getenv_mock.return_value = "true"
+
+        auth_request = RequestFactory().get(
+            "/foo", {"code": "foo", "state": "bar"}
+        )
+        auth_request.session = {}
+
+        jws_mock.return_value = jws_mock_return_value
+        get_json_mock = Mock()
+        get_json_mock.json.return_value = {
+            "gaspar": "sakai",
+            "email": "jin.sakai@epfl.ch",
+            "uniqueid": "000100",
+            "given_name": "Jin",
+            "family_name": "Sakai",
+        }
+        get_json_mock.headers = {"content-type": "application/json"}
+        request_mock.get.return_value = get_json_mock
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": jwt.encode(
+                {"some": "payload"}, "foobar", algorithm="HS256"
+            ),
+            "access_token": "access_granted",
+        }
+        request_mock.post.return_value = post_json_mock
+
+        user = self.backend.authenticate(request=auth_request)
+        self.assertIsNone(user)
+
+    @patch("os.getenv")
+    @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
+    @patch("mozilla_django_oidc.auth.requests")
+    @override_settings(OIDC_USE_NONCE=False)
+    def test_authenticate_rights_enabled_accepted(
+        self, request_mock, jws_mock, getenv_mock
+    ):
+        getenv_mock.return_value = "true"
+
+        auth_request = RequestFactory().get(
+            "/foo", {"code": "foo", "state": "bar"}
+        )
+        auth_request.session = {}
+
+        jws_mock.return_value = jws_mock_return_value
+        get_json_mock = Mock()
+        get_json_mock.json.return_value = {
+            "gaspar": "sakai",
+            "email": "jin.sakai@epfl.ch",
+            "uniqueid": "000100",
+            "given_name": "Jin",
+            "family_name": "Sakai",
+            "authorizations": ["MonDroitSecretEPFL"],
+        }
+        get_json_mock.headers = {"content-type": "application/json"}
+        request_mock.get.return_value = get_json_mock
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": jwt.encode(
+                {"some": "payload"}, "foobar", algorithm="HS256"
+            ),
+            "access_token": "access_granted",
+        }
+        request_mock.post.return_value = post_json_mock
+
+        user = self.backend.authenticate(request=auth_request)
+        self.assertIsNotNone(user)
+        self.assertEqual(user.username, "sakai")
+
+    @patch("os.getenv")
+    @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
+    @patch("mozilla_django_oidc.auth.requests")
+    @override_settings(OIDC_USE_NONCE=False)
+    def test_authenticate_rights_disabled_accepted(
+        self, request_mock, jws_mock, getenv_mock
+    ):
+        getenv_mock.return_value = "false"
+
+        auth_request = RequestFactory().get(
+            "/foo", {"code": "foo", "state": "bar"}
+        )
+        auth_request.session = {}
+
+        jws_mock.return_value = jws_mock_return_value
+        get_json_mock = Mock()
+        get_json_mock.json.return_value = {
+            "gaspar": "sakai",
+            "email": "jin.sakai@epfl.ch",
+            "uniqueid": "000100",
+            "given_name": "Jin",
+            "family_name": "Sakai",
+        }
+        get_json_mock.headers = {"content-type": "application/json"}
+        request_mock.get.return_value = get_json_mock
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": jwt.encode(
+                {"some": "payload"}, "foobar", algorithm="HS256"
+            ),
+            "access_token": "access_granted",
+        }
+        request_mock.post.return_value = post_json_mock
+
+        user = self.backend.authenticate(request=auth_request)
+        self.assertIsNotNone(user)
+        self.assertEqual(user.username, "sakai")
+
+    def test_verify_claims_fails_basic_verification(self):
+        bad_claims = {
+            "gaspar": "sakai",
+            "given_name": "Jin",
+            "family_name": "Sakai",
+            "authorizations": ["MonDroitSecretEPFL"],
+        }
+
+        result = self.backend.verify_claims(bad_claims)
+
+        self.assertFalse(result)

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -197,15 +197,10 @@ class EPFLOIDCABUserTestCase(TestCase):
         with pytest.raises(Exception):
             self.backend.authenticate(request=auth_request)
 
-    @patch("os.getenv")
     @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
     @patch("mozilla_django_oidc.auth.requests")
-    @override_settings(OIDC_USE_NONCE=False)
-    def test_authenticate_rights_enabled_rejected(
-        self, request_mock, jws_mock, getenv_mock
-    ):
-        getenv_mock.return_value = "true"
-
+    @override_settings(OIDC_USE_NONCE=False, OIDC_REQUIRE_AUTHORIZATIONS=True)
+    def test_authenticate_rights_enabled_rejected(self, request_mock, jws_mock):
         auth_request = RequestFactory().get(
             "/foo", {"code": "foo", "state": "bar"}
         )
@@ -235,55 +230,12 @@ class EPFLOIDCABUserTestCase(TestCase):
         user = self.backend.authenticate(request=auth_request)
         self.assertIsNone(user)
 
-    @patch("os.getenv")
     @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
     @patch("mozilla_django_oidc.auth.requests")
-    @override_settings(OIDC_USE_NONCE=False)
-    def test_authenticate_rights_enabled_accepted(
-        self, request_mock, jws_mock, getenv_mock
-    ):
-        getenv_mock.return_value = "true"
-
-        auth_request = RequestFactory().get(
-            "/foo", {"code": "foo", "state": "bar"}
-        )
-        auth_request.session = {}
-
-        jws_mock.return_value = jws_mock_return_value
-        get_json_mock = Mock()
-        get_json_mock.json.return_value = {
-            "gaspar": "sakai",
-            "email": "jin.sakai@epfl.ch",
-            "uniqueid": "000100",
-            "given_name": "Jin",
-            "family_name": "Sakai",
-            "authorizations": ["MonDroitSecretEPFL"],
-        }
-        get_json_mock.headers = {"content-type": "application/json"}
-        request_mock.get.return_value = get_json_mock
-
-        post_json_mock = Mock(status_code=200)
-        post_json_mock.json.return_value = {
-            "id_token": jwt.encode(
-                {"some": "payload"}, "foobar", algorithm="HS256"
-            ),
-            "access_token": "access_granted",
-        }
-        request_mock.post.return_value = post_json_mock
-
-        user = self.backend.authenticate(request=auth_request)
-        self.assertIsNotNone(user)
-        self.assertEqual(user.username, "sakai")
-
-    @patch("os.getenv")
-    @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
-    @patch("mozilla_django_oidc.auth.requests")
-    @override_settings(OIDC_USE_NONCE=False)
+    @override_settings(OIDC_USE_NONCE=False, OIDC_REQUIRE_AUTHORIZATIONS=False)
     def test_authenticate_rights_disabled_accepted(
-        self, request_mock, jws_mock, getenv_mock
+        self, request_mock, jws_mock
     ):
-        getenv_mock.return_value = "false"
-
         auth_request = RequestFactory().get(
             "/foo", {"code": "foo", "state": "bar"}
         )
@@ -319,7 +271,7 @@ class EPFLOIDCABUserTestCase(TestCase):
             "gaspar": "sakai",
             "given_name": "Jin",
             "family_name": "Sakai",
-            "authorizations": ["MonDroitSecretEPFL"],
+            "authorizations": ["Ghost"],
         }
 
         result = self.backend.verify_claims(bad_claims)

--- a/tests/test_user_auth.py
+++ b/tests/test_user_auth.py
@@ -232,10 +232,8 @@ class EPFLOIDCABUserTestCase(TestCase):
 
     @patch("django_epfl_entra_id.auth.EPFLOIDCAB._verify_jws")
     @patch("mozilla_django_oidc.auth.requests")
-    @override_settings(OIDC_USE_NONCE=False, OIDC_REQUIRE_AUTHORIZATIONS=False)
-    def test_authenticate_rights_disabled_accepted(
-        self, request_mock, jws_mock
-    ):
+    @override_settings(OIDC_USE_NONCE=False, OIDC_REQUIRE_AUTHORIZATIONS=True)
+    def test_authenticate_rights_enabled_accepted(self, request_mock, jws_mock):
         auth_request = RequestFactory().get(
             "/foo", {"code": "foo", "state": "bar"}
         )
@@ -249,6 +247,7 @@ class EPFLOIDCABUserTestCase(TestCase):
             "uniqueid": "000100",
             "given_name": "Jin",
             "family_name": "Sakai",
+            "authorizations": ["Ghost"],
         }
         get_json_mock.headers = {"content-type": "application/json"}
         request_mock.get.return_value = get_json_mock

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
@@ -37,3 +38,9 @@ class EPFLEntraIdLoginTestCase(TestCase):
         self.assertEqual(request.method, "GET")
         self.assertEqual(request.path, "/admin/login/")
         self.assertEqual(request.get_full_path(), "/admin/login/")
+
+    def test_forbidden_view_raises_permission_denied(self):
+        request = self.factory.get("/forbidden/")
+
+        with self.assertRaises(PermissionDenied):
+            views.forbidden_view(request)


### PR DESCRIPTION
Implemented a rights-based authentication check that validates the custom authorizations claim injected by EPFL's Entra ID. Introduced an environment variable feature flag (AUTHENTICATION_RIGHTS) to dynamically toggle this restriction. When enabled, users who successfully log in but lack the required permissions are automatically blocked and redirected to a dedicated Forbidden error page.